### PR TITLE
Update Elvia prices valid from April 1st 2025

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -74,6 +74,9 @@
       },
       {
         "name": "Frode Heggelund"
+      },
+      {
+        "name": "Philip Østli"
       }
     ]
   },

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -87,5 +87,6 @@
       }
     }
   },
-  "homeyCommunityTopicId": 56678
+  "homeyCommunityTopicId": 56678,
+  "source": "https://github.com/balmli/no.almli.utilitycost"
 }

--- a/app.json
+++ b/app.json
@@ -75,6 +75,9 @@
       },
       {
         "name": "Frode Heggelund"
+      },
+      {
+        "name": "Philip Østli"
       }
     ]
   },

--- a/app.json
+++ b/app.json
@@ -89,6 +89,7 @@
     }
   },
   "homeyCommunityTopicId": 56678,
+  "source": "https://github.com/balmli/no.almli.utilitycost",
   "flow": {
     "triggers": [
       {

--- a/data/gridprices.json
+++ b/data/gridprices.json
@@ -110,6 +110,20 @@
         "gridEnergyNight": 0.3250,
         "gridEnergyLowWeekends": true,
         "gridEnergyLowHoliday": true
+      },
+      {
+        "validFrom": "2025-04-01",
+        "gridCapacity0_2": 125,
+        "gridCapacity2_5": 190,
+        "gridCapacity5_10": 300,
+        "gridCapacity10_15": 410,
+        "gridCapacity15_20": 520,
+        "gridCapacity20_25": 630,
+        "gridCapacityAverage": "3",
+        "gridEnergyDay": 0.4865,
+        "gridEnergyNight": 0.3865,
+        "gridEnergyLowWeekends": true,
+        "gridEnergyLowHoliday": true
       }
     ]
   },


### PR DESCRIPTION
[Price source](https://www.elvia.no/siteassets/dokumenter/priser/2025/1-april-2025/tariffblad_1_0_standard_tariff_privat_20250401.pdf)

- Adds price interval for Elvia valid from 01.04.2025
- Adds link to source code
- Adds me as contributor